### PR TITLE
fix: run Bruno tests from collection root

### DIFF
--- a/specs/api/run-api-tests-bruno.sh
+++ b/specs/api/run-api-tests-bruno.sh
@@ -11,9 +11,11 @@ if [ ${#FOLDERS[@]} -eq 0 ]; then
   for entry in "$DIR"/bruno/*/; do
     name="$(basename "$entry")"
     [ "$name" = "environments" ] && continue
-    FOLDERS+=("$entry")
+    FOLDERS+=("$name")
   done
 fi
+
+cd "$DIR/bruno"
 
 for folder in "${FOLDERS[@]}"; do
   echo ""


### PR DESCRIPTION
## Summary

- `bru run` requires execution from the collection root (the directory containing `bruno.json`). The script was passing absolute subdirectory paths to `bru run`, which caused the error _"You can run only at the root of a collection"_.
- Fix by `cd`-ing into the `bruno/` collection root before the loop and storing only the `basename` of each folder in the `FOLDERS` array.

## Test plan

- [ ] Run `HOST=http://localhost:8000 specs/api/run-api-tests-bruno.sh` against a running RealWorld server and confirm all Bruno test folders execute without the collection root error